### PR TITLE
Update regular expression

### DIFF
--- a/lib/slug-generator.js
+++ b/lib/slug-generator.js
@@ -124,7 +124,7 @@ function makeUniqueCounterSlug(doc, field, values, options, padding, next) {
         match = null,
         test = new RegExp(options.separator + '(\\d+)$'),
         query = {},
-        search = new RegExp(slug + "(" + options.separator + '(\\d+))?$'),
+        search = new RegExp('^' + slug + "(" + options.separator + '(\\d+))?$'),
         sort = {};
 
     sort[field] = -1;


### PR DESCRIPTION
When adding records like:

```
{ name: 'something' },
{ name: 'thing' },
{ name: 'thing' }
```

I'm getting an error like:

```
'E11000 duplicate key error collection: xxx.xxx index: slug_1 dup key: { : "thing-01" }'
```
