### PR TITLE
Migrating from Mongoose 6.x to 7.x

### DIFF
--- a/lib/slug-generator.js
+++ b/lib/slug-generator.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var getSlug = require('speakingurl'),
-    shortId  = require('shortid'),
+    shortId = require('shortid'),
     async = require('async');
 
 module.exports = function (schema, options) {
@@ -26,7 +26,7 @@ module.exports = function (schema, options) {
                 "name": pathname
             };
 
-            if (typeof(schemaType.options.slug) === "string") {
+            if (typeof (schemaType.options.slug) === "string") {
                 slug.values = [schemaType.options.slug]
             } else if (schemaType.options.slug instanceof Array) {
                 slug.values = schemaType.options.slug
@@ -95,7 +95,7 @@ module.exports = function (schema, options) {
                         callback();
                     })
                 } else {
-                    makeUniqueCounterSlug(doc, item.name, values, opts, item.padding , function (err, slug) {
+                    makeUniqueCounterSlug(doc, item.name, values, opts, item.padding, function (err, slug) {
                         if (!doc[item.name] || !(item.permanent && doc[item.name])) {
                             doc[item.name] = slug;
                         }
@@ -147,23 +147,30 @@ function makeUniqueCounterSlug(doc, field, values, options, padding, next) {
     query[field] = search;
 
     // field = search and doc != doc
-    doc.model(doc.constructor.modelName).findOne(query).sort(sort).exec(function (err, result) {
-        if (result) {
-            if (match = result[field].match(test)) {
-                count = match[1];
+    doc
+        .model(doc.constructor.modelName)
+        .findOne(query)
+        .sort(sort)
+        .then((result) => {
+            if (result) {
+                if (match = result[field].match(test)) {
+                    count = match[1];
+                }
+                count++;
+                slug += options.separator + pad(count, padding);
             }
-            count++;
-            slug += options.separator + pad(count, padding);
-        }
 
-        next(null, slug);
+            next(null, slug);
 
-    })
+        })
+        .catch(err => {
+            next(null, slug);
+        })
 
 }
 
 function pad(num, size) {
-    var s = num+"";
+    var s = num + "";
     while (s.length < size) s = "0" + s;
     return s;
 }
@@ -184,11 +191,17 @@ function makeUniqueShortIdSlug(doc, field, values, options, next) {
 
     query[field] = slug;
 
-    doc.model(doc.constructor.modelName).findOne(query).exec(function (err, result) {
-        if (result) {
-            slug += options.separator + shortId.generate();
-        }
+    doc
+        .model(doc.constructor.modelName)
+        .findOne(query)
+        .then((result) => {
+            if (result) {
+                slug += options.separator + shortId.generate();
+            }
 
-        next(null, slug);
-    });
+            next(null, slug);
+        })
+        .catch(err => {
+            next(null, slug);
+        });
 }


### PR DESCRIPTION
In the new version of Mongoose (v7) Query.prototype.exec() no longer accepts a callback